### PR TITLE
We didn't set the from_api flag for monitors

### DIFF
--- a/app/controllers/monitors_controller.rb
+++ b/app/controllers/monitors_controller.rb
@@ -17,7 +17,7 @@ class MonitorsController < ApplicationController
     if @form.validate(params[:monitor])
       
       @bm = BundleManager.new(current_user.account)
-      @bundle, error = @bm.create(@form.platform_release, {name: @form.name}, @form.package_list)
+      @bundle, error = @bm.create(@form.platform_release, {name: @form.name, from_api: true}, @form.package_list)
 
       if error
         @form.errors.add(:base, error.message)


### PR DESCRIPTION
@phillmv  we didn't set this flag BUT in other places, i.e `Bundle.via_api`, we're defining monitors as bundles where `:agen_server_id => nil`

So which one is it?
