### PR TITLE
Allow the use of "/" chars in monitor names

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,11 +122,11 @@ Rails.application.routes.draw do
       post "check" => 'check#create'
       get "status" => 'status#status'
 
-      post "monitors(/:name)" => "monitors#create", :constraints => { :name => /.*/ }
-      put "monitors/:name" => "monitors#update", :constraints => { :name => /.*/ }
-      get "monitors/:name" => "monitors#show", :constraints => { :name => /.*/ }, :as => "monitor"
+      post "monitors(/:name)" => "monitors#create", :constraints => { :name => /.+(?=\.json|\.html|$)/ }
+      put "monitors/:name" => "monitors#update", :constraints => { :name => /.+(?=\.json|\.html|$)/ }
+      get "monitors/:name" => "monitors#show", :constraints => { :name => /.+(?=\.json|\.html|$)/ }, :as => "monitor"
       get "monitors" => "monitors#index"
-      delete "monitors/:name" => "monitors#destroy", :constraints => { :name => /.*/ }
+      delete "monitors/:name" => "monitors#destroy", :constraints => { :name => /.+(?=\.json|\.html|$)/ }
 
       get "servers/:uuid" => "servers#show", :as => "server"
       get "servers" => "servers#index"


### PR DESCRIPTION
This (un)constrains the path matching for the monitor routes, by allowing any character including a "/" to continue a monitor name.

I'm a little concerned that this will prohibit the extension of that path (for example, when monitors have child resources which we'd like to nest under them).