### PR TITLE
Set production/staging log level to info

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
We should not be logging debug level in production and here is my overwhelming case for it.

# How much do we log anyway?

We rotate and compress logs weekly. Last week's log (uncompressed) was 15GB. This weeks is 20GB so far. It's set to rotate on the 25th. We had a big week with lots of new logs because of the source name things, but going forward this is only going to get bigger.

We finally ran out of space on production today. (I freed up 8 gigs by deleting a temporary log file I made for myself, this is going to happen again, and soon!)

# Why does it take up so much space?

There are two things that are the biggest space wasters: we log every request and that's a log of multi-megabyte sized base64 encoded dpkg/statuses in the request parameters, and we are logging all the sql transactions so we have walls of text of stuff like 

```
D, [2016-12-18T06:32:16.271591 #5863] DEBUG -- :   ESC[1mESC[36mBundledPackage Load (76.9ms)ESC[0m  ESC[1mSELECT "bundled_packages".bundle_id,
           "bundled_packages".id bundled_package_id,
           "bundled_packages".package_id,
           "vulnerable_packages".id vulnerable_package_id,
           "vulnerable_packages".vulnerable_dependency_id,
           "vulnerable_packages".vulnerability_id,
           "bundled_packages".valid_at occurred_at FROM "bundled_packages" INNER JOIN "vulnerable_packages" ON
           "vulnerable_packages".package_id = "bundled_packages".package_id WHERE (NOT EXISTS
           (SELECT 1 FROM "log_bundle_vulnerabilities" lbv
           WHERE lbv.bundle_id = "bundled_packages".bundle_id AND
                 lbv.package_id = "bundled_packages".package_id AND
                 lbv.bundled_package_id = "bundled_packages".id AND
                 lbv.vulnerability_id = "vulnerable_packages".vulnerability_id AND
                 lbv.vulnerable_dependency_id = "vulnerable_packages".vulnerable_dependency_id AND
                 lbv.vulnerable_package_id = "vulnerable_packages".id)) AND "bundled_packages"."bundle_id" = $1ESC[0m  [["bundle_id", 1027]]
D, [2016-12-18T06:32:16.280804 #5863] DEBUG -- :   ESC[1mESC[35mBundledPackageArchive Load (4.9ms)ESC[0m  SELECT "bundled_package_archives".bundle_id,
           "bundled_package_archives".package_id,
           "bundled_package_archives".bundled_package_id,
           "bundled_package_archives".expired_at occurred_at,
           "vulnerable_packages".id vulnerable_package_id,
           "vulnerable_packages".vulnerable_dependency_id vulnerable_dependency_id,
           "vulnerable_packages".vulnerability_id FROM "bundled_package_archives" INNER JOIN "vulnerable_packages" ON
            "vulnerable_packages".package_id = "bundled_package_archives".package_id WHERE ("vulnerable_packages".valid_at < "bundled_package_archives".expired_at) AND "bundled_package_archives"."bundle_id" =
 $1 AND (bundled_package_id NOT IN
            (SELECT "bundled_packages"."id" FROM "bundled_packages" INNER JOIN "vulnerable_packages" ON
```

 I did a quick check on the first million lines of this weeks log, and it's about 1-1. So cutting one of those is going to halve our log size.

# Why log less?
> I'm willing to test the boundaries of what is too many logs, cos I've been bitten by not enough logs but this is the very first time too many logs has been a problem
- @phillmv 

I completely agree. Basically I want to be able to do 4 things with logs

1) Debug issues that happened in the past
2) Stream logs as I am giving a user support
3) Look at historical performance as we try to speed up queries
4) In case of disaster, replay traffic

I have had to do the first three this week, and the size of our log file made them very hard if not impossible.

## Examples

1) Eligible's servers weren't being updated after they ran apt-get update. This was because our workers were timing out. I could find the requests in the log, but there would more than 10k lines of SQL queries between the request and the response (some vulnerability or advisory importer is always logging to add to the jumble). After about 45 minutes with grep, I finally found the issue by reading the unicorn.stderr.log file which just logged the worker's crashing and correlating the process IDs. What should have been a 5 minute job took over an hour.

2) After I deployed a fix, eligible was still having the same problem and restarting their agents while on the chat with me. I had no way of streaming logs to see what was happening because the logs are a hot mess of SQL queries

3) Eligible again is complaining that the dashboard takes a long time to load. This is actually a case where seeing timing information for SQL queries can be useful BUT when actually working on this bug I will be able to test locally with live data. I care about a request taking a long time, but I don't actually care to see the thousands of SQL queries it ran individually.

Which brings me to my 

# Conclusion

If we change the log level to info, our logs will become *more* useful not less. We'll be able to visually see related requests, without them being lost in the noise, we'll be able to stream logs, we'll be able to replay requests (the requests with their megabyte blobs of dpkg statuses are still logged!) and we'll be less worried about running out of space.

I have worked with the logs a lot this week and I found having the SQL stuff in them made my quality of life as a developer lower. 

I can only think of one situation where we want the SQL queries in our log, and it's for timing information as we tune performance. BUT we still get the overall ActiveRecord / View time per request when we log info and the granular per-query timing info is a lot more useful in development as you develop/test with real data.

Also, logging to info in production was the default before Rails 4.2.0. I think that it's a an okay default when your SQL queries aren't as numerous and complicated per request as ours are.

So @phillmv, given that we still have the full request log and timing information, can you make a compelling case for us needing the debug log of a bunch of queries that look like this?

```
D, [2016-12-23T14:17:24.513082 #11348] DEBUG -- :   Advisory Load (10.0ms)  SELECT  "advisories".* FROM "advisories" WHERE "advisories"."identifier" = $1 AND "advisories"."source" = $2  ORDER BY created_at DESC LIMIT 1  [["identifier", "CVE-2004-1141"], ["source", "ubuntu-cve-tracker"]]
D, [2016-12-23T14:17:24.517796 #11348] DEBUG -- :   Package Load (334.7ms)  SELECT "packages".* FROM "packages" inner join vulnerable_dependencies vd on "packages".platform = vd.platform WHERE (name = package_name OR source_name = package_name) AND (vulnerability_id = 29053)
D, [2016-12-23T14:17:24.521402 #11348] DEBUG -- :   SQL (4.2ms)  DELETE FROM "advisory_import_states" WHERE "advisory_import_states"."id" = $1  [["id", 9261503]]
D, [2016-12-23T14:17:24.713275 #11348] DEBUG -- :    (192.2ms)  BEGIN
D, [2016-12-23T14:17:24.713858 #11348] DEBUG -- :   SQL (91.1ms)  INSERT INTO "advisory_import_states" ("advisory_id", "created_at", "updated_at") VALUES ($1, $2, $3) RETURNING "id"  [["advisory_id", 8204], ["created_at", "2016-12-23 14:17:24.620740"], ["updated_at", "2016-12-23 14:17:24.620740"]]
D, [2016-12-23T14:17:24.813573 #11348] DEBUG -- :   AdvisoryImportState Load (98.3ms)  SELECT  "advisory_import_states".* FROM "advisory_import_states" WHERE "advisory_import_states"."advisory_id" = $1 LIMIT 1  [["advisory_id", 11591]]
D, [2016-12-23T14:17:25.013741 #11348] DEBUG -- :    (93.5ms)  COMMIT
D, [2016-12-23T14:17:25.014400 #11348] DEBUG -- :   SQL (79.7ms)  DELETE FROM "advisory_import_states" WHERE "advisory_import_states"."id" = $1  [["id", 9257213]]
D, [2016-12-23T14:17:25.114000 #11348] DEBUG -- :   Advisory Load (97.3ms)  SELECT  "advisories".* FROM "advisories" WHERE "advisories"."identifier" = $1 AND "advisories"."source" = $2  ORDER BY created_at DESC LIMIT 1  [["identifier", "CVE-2016-7410-dwarfutils"], ["source", "debian-tracker"]]
D, [2016-12-23T14:17:25.314142 #11348] DEBUG -- :   SQL (94.5ms)  INSERT INTO "advisory_import_states" ("advisory_id", "created_at", "updated_at") VALUES ($1, $2, $3) RETURNING "id"  [["advisory_id", 11591], ["created_at", "2016-12-23 14:17:25.217966"], ["updated_at", "2016-12-23 14:17:25.217966"]]
D, [2016-12-23T14:17:25.416211 #11348] DEBUG -- :    (99.8ms)  BEGIN
D, [2016-12-23T14:17:25.514391 #11348] DEBUG -- :    (98.3ms)  COMMIT
```



