### PR TITLE
Use wget to mirror alas website

### DIFF
--- a/lib/wget_handler.rb
+++ b/lib/wget_handler.rb
@@ -1,0 +1,19 @@
+require 'open3'
+
+class WgetHandler
+  attr_accessor :klass_name, :mirror_url, :local_path, :mirror_pattern
+  def initialize(klass, url, path, pattern)
+    self.klass_name = klass.name
+    self.mirror_url = url
+    self.mirror_pattern = pattern
+    self.local_path = path
+  end
+
+  def mirror!
+    # no host directories, no parent, timestamping recursive
+    output, process = Open3.capture2e("wget -nH -np -N -r -A \"#{mirror_pattern}\"  -P #{local_path} #{mirror_url}")
+    unless process.success?
+      raise "#{klass_name} - something when wrong mirroring: #{output}"
+    end
+  end
+end

--- a/test/importers/alas_importer_test.rb
+++ b/test/importers/alas_importer_test.rb
@@ -2,7 +2,8 @@ require 'test_helper'
 
 class AlasImporterTest < ActiveSupport::TestCase
   it "should do the right thing" do
-    @importer = AlasImporter.new(File.join(Rails.root, "test/data/importers/alas/index.html"))
+    AlasImporter.any_instance.stubs(:update_local_store!).returns(true)
+    @importer = AlasImporter.new("not a real website", "test/data/importers/alas")
 
     assert_equal 0, Advisory.from_alas.count
     


### PR DESCRIPTION
I realized when working on rhsa importer that we can't just redownload the entire HTML repository every time we run the vuln importer -- it would take for fucking ever.

This PR uses wget to create a mirror of the website and updates the mirror every time the importer is rerun. This makes sure we only download files if they are modified and thus behave better. In clojure-land I implemented this myself, but wget is going to be smarter than me probably.

Downside: wget is single threaded :( 

