### PR TITLE
assert_equal nil, val -> to assert_nil val

### DIFF
--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -34,7 +34,7 @@ class DashboardControllerTest < ActionController::TestCase
       it "should be redirected to onboarding path" do
         get :index
         assert_redirected_to onboarding_path
-        assert_equal flash[:notice], nil
+        assert_nil flash[:notice]
       end
 
       it "but tried to add a server, should display flash" do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -82,8 +82,8 @@ class UsersControllerTest < ActionController::TestCase
 
     test "users should be able to update preferences" do
       login_user(user)
-      assert_equal user.pref_os, nil
-      assert_equal user.pref_deploy, nil
+      assert_nil user.pref_os
+      assert_nil user.pref_deploy
       xhr :patch, :update, :id => user.id, :user => { :pref_os => "ubuntu", :pref_deploy => "chef" }
       assert_response :success
 

--- a/test/integration/check_api_test.rb
+++ b/test/integration/check_api_test.rb
@@ -40,7 +40,7 @@ class CheckApiTest < ActionDispatch::IntegrationTest
         assert_equal 1, account.log_api_calls.where(:action => "check/create").count
         # Make sure we log the right platform release
         assert_equal "ruby", account.log_api_calls.last.platform
-        assert_equal nil, account.log_api_calls.last.release
+        assert_nil account.log_api_calls.last.release
 
         json = json_body
         assert json.key?("data")

--- a/test/mgmt/email_manager_test.rb
+++ b/test/mgmt/email_manager_test.rb
@@ -85,8 +85,8 @@ class EmailManagerTest < ActiveSupport::TestCase
     assert_equal email1.account_id, bundle1.account_id
     assert_equal email2.account_id, bundle3.account_id
 
-    assert_equal nil, email1.sent_at
-    assert_equal nil, email2.sent_at
+    assert_nil email1.sent_at
+    assert_nil email2.sent_at
     assert_equal 1, email1.notifications.count
     assert_equal 3, email2.notifications.count
 
@@ -138,8 +138,8 @@ class EmailManagerTest < ActiveSupport::TestCase
     assert_equal email1.account_id, bundle1.account_id
     assert_equal email2.account_id, bundle2.account_id
 
-    assert_equal nil, email1.sent_at
-    assert_equal nil, email2.sent_at
+    assert_nil email1.sent_at
+    assert_nil email2.sent_at
     assert_equal 1, email1.notifications.count
     assert_equal 2, email2.notifications.count
 

--- a/test/mgmt/package_manager_test.rb
+++ b/test/mgmt/package_manager_test.rb
@@ -182,7 +182,7 @@ class PackageManagerTest < ActiveSupport::TestCase
 
     pkg = FactoryGirl.create(:package, :ubuntu, :origin => "user")
     assert_equal 1, Package.count
-    assert_equal nil, pkg.source_name
+    assert_nil pkg.source_name
     assert_equal 0, VulnerablePackage.count
 
     # in ubuntu, vulns are calculated using the source name.
@@ -198,7 +198,7 @@ class PackageManagerTest < ActiveSupport::TestCase
     @pm.find_or_create([parcel])
 
     pkg.reload
-    assert_equal nil, pkg.source_name
+    assert_nil pkg.source_name
     assert_equal 0, VulnerablePackage.count
 
     # now we actually try to update the package

--- a/test/mgmt/vulnerability_manager_test.rb
+++ b/test/mgmt/vulnerability_manager_test.rb
@@ -40,7 +40,7 @@ class VulnerabilityManagerTest < ActiveSupport::TestCase
     assert_equal 3, diffed.count
     assert_equal 2, diffed[0].id, "should actually be object from existing"
     assert_equal 3, diffed[1].id, "should actually be object from existing"
-    assert_equal nil, diffed[2].id, "should be new object"
+    assert_nil diffed[2].id, "should be new object"
 
     ## okay. what about if the new array is empty?
 

--- a/test/models/platform_release_test.rb
+++ b/test/models/platform_release_test.rb
@@ -3,51 +3,51 @@ require 'test_helper'
 class PackageReleaseTest < ActiveSupport::TestCase
   it "should work for ruby" do
     pr, err = PlatformRelease.validate(Platforms::Ruby)
-    assert_equal nil, err
+    assert_nil err
 
     assert_equal "ruby", pr.platform
-    assert_equal nil, pr.release
+    assert_nil pr.release
 
 
     pr, err = PlatformRelease.validate(Platforms::Ruby, "lol")
-    assert_equal nil, pr
+    assert_nil pr
 
     assert_equal({:release=>["is invalid"]}, err.messages)
 
     pr, err = PlatformRelease.validate("RUBY")
-    assert_equal nil, pr
+    assert_nil pr
   end
 
   it "should work for centos" do
     pr, err = PlatformRelease.validate(Platforms::CentOS)
-    assert_equal nil, pr
+    assert_nil pr
 
     assert_equal({:release=>["is invalid"]}, err.messages)
 
     pr, err = PlatformRelease.validate(Platforms::CentOS, "4")
-    assert_equal nil, pr
+    assert_nil pr
 
     assert_equal({:release=>["is invalid"]}, err.messages)
 
     pr, err = PlatformRelease.validate("centosh", "6")
-    assert_equal nil, pr
+    assert_nil pr
 
     assert_equal({:platform=>["is invalid"]}, err.messages)
 
     pr, err = PlatformRelease.validate(Platforms::CentOS, "7")
-    assert_equal nil, err
+    assert_nil err
 
     assert_equal "centos", pr.platform
     assert_equal "7", pr.release
 
     pr, err = PlatformRelease.validate(Platforms::CentOS, "6")
-    assert_equal nil, err
+    assert_nil err
 
     assert_equal "centos", pr.platform
     assert_equal "6", pr.release
 
     pr, err = PlatformRelease.validate(Platforms::CentOS, "5")
-    assert_equal nil, err
+    assert_nil err
 
     assert_equal "centos", pr.platform
     assert_equal "5", pr.release
@@ -57,26 +57,26 @@ class PackageReleaseTest < ActiveSupport::TestCase
 
   it "should work for ubuntu" do
     pr, err = PlatformRelease.validate(Platforms::Ubuntu)
-    assert_equal nil, pr
+    assert_nil pr
 
     assert_equal({:release=>["is invalid"]}, err.messages)
 
 
     pr, err = PlatformRelease.validate(Platforms::Ubuntu, "16.05")
-    assert_equal nil, pr
+    assert_nil pr
 
     assert_equal({:release=>["is invalid"]}, err.messages)
 
 
     pr, err = PlatformRelease.validate(Platforms::Ubuntu, "16.04")
-    assert_equal nil, err
+    assert_nil err
 
     assert_equal "ubuntu", pr.platform
     assert_equal "xenial", pr.release
 
 
     pr, err = PlatformRelease.validate(Platforms::Ubuntu, "16.04.3")
-    assert_equal nil, err
+    assert_nil err
 
     assert_equal "ubuntu", pr.platform
     assert_equal "xenial", pr.release
@@ -85,19 +85,19 @@ class PackageReleaseTest < ActiveSupport::TestCase
 
    it "should work for debian" do
     pr, err = PlatformRelease.validate(Platforms::Debian)
-    assert_equal nil, pr
+    assert_nil pr
 
     assert_equal({:release=>["is invalid"]}, err.messages)
 
 
     pr, err = PlatformRelease.validate(Platforms::Debian, "8.5")
-    assert_equal nil, pr
+    assert_nil pr
 
     assert_equal({:release=>["is invalid"]}, err.messages)
 
 
     pr, err = PlatformRelease.validate(Platforms::Debian, "8")
-    assert_equal nil, err
+    assert_nil err
 
     assert_equal "debian", pr.platform
     assert_equal "jessie", pr.release

--- a/test/presenters/vuln_presenter_test.rb
+++ b/test/presenters/vuln_presenter_test.rb
@@ -9,7 +9,7 @@ class VulnPresenterTest < ActiveSupport::TestCase
     assert_equal "example.com", vp.get_host_without_www("https://example.com")
     assert_equal "example.com", vp.get_host_without_www("http://example.com sometimes they leave comments")
 
-    assert_equal nil, vp.get_host_without_www("http://example.com/foo{}$$ test")
+    assert_nil vp.get_host_without_www("http://example.com/foo{}$$ test")
   end
 end
 


### PR DESCRIPTION
Minitest was complaining that these assertions will fail in MT6.