### PR TITLE
Speedup the package merge function

### DIFF
--- a/lib/package_merger.rb
+++ b/lib/package_merger.rb
@@ -13,9 +13,8 @@ class PackageMerger
 
         # Make sure all the affected bundles have the canonical package
         all_bundles.each do |b|
-          if !b.packages.include?(canonical_pkg)
+          unless b.packages.include?(canonical_pkg)
             b.packages << canonical_pkg
-            b.save
           end
         end
 


### PR DESCRIPTION
We were spending too much time loading packages for each bundle when making the
bundlepackages a set, and this timed out the transaction.

Now we just check to see if the bundle has the "canonical package" and add it if
it doesn't.

What this doesn't do is solve the problem of duplicate bundledpackages as
opposed to duplicate *packages*. That is, if we have more than one
bundledpackage for the same bundle_id,package_id, we won't delete it here. This
is a separate problem anyway, and it was bad to merge them together. As
discussed we need to add an uniq constraint and some kind of functionality to
make sure we don't do this.

This PR is now limiting the merge_dupe_packages to just merge duplicate packages
that share a name,version,release,arch.

Closes #270