### PR TITLE
RHSA: Import data from the last 6 months each run

### DIFF
--- a/app/importers/rhsa_importer.rb
+++ b/app/importers/rhsa_importer.rb
@@ -10,7 +10,7 @@ class RHSAImporter < AdvisoryImporter
   attr_reader :after
 
   def initialize(after = nil)
-    @after = after || 2.hours.ago
+    @after = after || 6.months.ago
   end
 
   def fetch_advisories


### PR DESCRIPTION
See the following exchange with RH Security:

```
From: Red Hat Product Security <secalert@redhat.com>
To: j@appcanary.com
Subject: [engineering.redhat.com #445284] question about the security data api
Date: Tue 09 May 2017 10:39:17 AM EDT

Hi Jonathan,

Sorry for the delay caused on my part! Here are the answers for your questions:

On Wed Apr 26 17:26:07 2017, amaris@redhat.com wrote:
> On Tue Apr 25 21:01:41 2017, j@appcanary.com wrote:
> > Hi folks
> >
> > I'm writing an importer for RH Security Advisories, and using your new
> > security data API and I have questions about the `before` and `after`
> > parameters, particularly in the case of CVRF docs.
> >
> > First question: is it possible for an exising RHSA to be updated (i.e.,
> > are they mutable)?

Yes, it is possible, but it's quite a rare event. That said, it has already
happened and it most likely will happen in the future as well.

> >
> > Second: if so, will an old RHSA, say, created 1 year ago, which has been
> > updated today, be successfully retrieved by a query which has an `after`
> > parameter of yesterday.

No, parameters `after` and `before` correspond to release date.

> >
> > Third: if not, is there any other way to retrieve CVRF docs which have
> > been modbified?

As of now, unfortunately not.

Best Regards,

--
Adam Mariš / Red Hat Product Security

```

Based on the following benchmark, for the entire import, subsequent import of the last 6 months, and then overthe last year, I've gone with a 6 month query.

```ruby
[#<Benchmark::Tms:0x0055dfa582ead0 @cstime=0.0, @cutime=0.0, @label="", @real=1574.077699861009, @stime=10.63, @total=245.39, @utime=234.76>,
 #<Benchmark::Tms:0x0055dfa571f0b8 @cstime=0.0, @cutime=0.0, @label="", @real=192.23242374799156, @stime=0.8200000000000003, @total=19.56000000000001, @utime=18.74000000000001>,
 #<Benchmark::Tms:0x0055df9bef7c18 @cstime=0.0, @cutime=0.0, @label="", @real=340.9163502110023, @stime=1.6100000000000012, @total=44.45000000000003, @utime=42.84000000000003>]
```