### PR TITLE
Speed up email query

### DIFF
--- a/app/mgmt/email_manager.rb
+++ b/app/mgmt/email_manager.rb
@@ -27,7 +27,7 @@ class EmailManager
 
 
   def self.queue_vuln_emails!
-    accounts = Account.with_unnotified_vuln_logs.joins(:users).
+    accounts = Account.joins(:users).
       where(users: { :pref_email_frequency => PrefOpt::EMAIL_WANTS_FIREHOSE})
 
 
@@ -37,7 +37,7 @@ class EmailManager
   end
 
    def self.queue_patched_emails!
-     accounts = Account.with_unnotified_patch_logs.joins(:users).
+     accounts = Account.joins(:users).
       where(users: { :pref_email_frequency => PrefOpt::EMAIL_WANTS_FIREHOSE})
 
     accounts.select do |acct|


### PR DESCRIPTION
@phillmv  the query you asked me to look at came from the EmailManager which found every user that had outstanding notifications that wanted them before building a vuln/patched email for each of those users.

In building the email, we query the notifications table again for each account:

```ruby
unnotified_logs = VulnQuery.new(acct).unnotified_vuln_logs.where("log_bundle_vulnerabilities.created_at >= ? ", 2.days.ago)
# ...
if unnotified_logs.any?
        email = EmailVulnerable.create!(:account => acct)
```

Seeing that, it seems like the fastest fix here is to just get rid of the the slow query that tries to guess which accounts have notifications to send and just do the faster query (scoped to the last 2 days of events) for every account.

Can you sanity check this?
